### PR TITLE
Genomic annotations query through pgsql functions

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -38,11 +38,11 @@ ENV I2B2_HIVE_URL=http://i2b2:8080/i2b2/services \
     MEDCO_NODES_URL="http://medco-connector-srv0/medco,http://medco-connector-srv1/medco,http://medco-connector-srv2/medco" \
     MEDCO_NODE_IDX=0 \
     MEDCO_OBFUSCATION_MIN=5 \
-    PG_DBMS_HOST=postgresql \
-    PG_DBMS_PORT=5432 \
-    PG_DB_USER=i2b2 \
-    PG_DB_PW=i2b2 \
-    PG_DB_NAME=i2b2medco
+    GA_DB_HOST=postgresql \
+    GA_DB_PORT=5432 \
+    GA_DB_USER=genomicannotations \
+    GA_DB_PW=genomicannotations \
+    GA_DB_NAME=gamedcosrv
 
 EXPOSE 1999
 ENTRYPOINT docker-entrypoint.sh medco-connector-server --write-timeout=${SERVER_HTTP_WRITE_TIMEOUT_SECONDS}s

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -25,11 +25,11 @@ services:
       - MEDCO_OBFUSCATION_MIN=5
       - MEDCO_NODES_URL=http://medco-connector-srv0/medco,http://medco-connector-srv1/medco,http://medco-connector-srv2/medco
       - MEDCO_NODE_IDX=0
-      - PG_DBMS_HOST=postgresql
-      - PG_DBMS_PORT=5432
-      - PG_DB_USER=i2b2
-      - PG_DB_PW=i2b2
-      - PG_DB_NAME=i2b2medco
+      - GA_DB_HOST=postgresql
+      - GA_DB_PORT=5432
+      - GA_DB_USER=genomicannotations
+      - GA_DB_PW=genomicannotations
+      - GA_DB_NAME=gamedcosrv
     volumes:
       - ./configuration-profile:/medco-configuration
 

--- a/server/handlers/genomic_annotations_test.go
+++ b/server/handlers/genomic_annotations_test.go
@@ -1,4 +1,4 @@
-package tests
+package handlers
 
 import (
 	"github.com/ldsec/medco-connector/restapi/server/operations/genomic_annotations"
@@ -92,8 +92,8 @@ func testGenomicAnnotationsGetValues(query_type string, query_value string, quer
 	params.Annotation = query_type
 	params.Value = query_value
 
-	query := "SELECT annotation_value FROM genomic_annotations." + params.Annotation + " WHERE annotation_value ~* $1 ORDER BY annotation_value LIMIT $2"
-	rows, err := utilserver.DBConnection.Query(query, params.Value, *params.Limit)
+	query, _ := buildGetValuesQuery(params)
+	rows, err := utilserver.DBConnection.Query(query, params.Annotation, params.Value, *params.Limit)
 	if err != nil {
 		logrus.Error("Query execution error " + err.Error())
 		t.Fail()
@@ -140,8 +140,8 @@ func testGenomicAnnotationsGetVariants(query_type string, query_value string, zy
 		}
 	}
 
-	query := "SELECT variant_id FROM genomic_annotations.genomic_annotations WHERE " + params.Annotation + " = $1 AND annotations ~* $2 ORDER BY variant_id"
-	rows, err := utilserver.DBConnection.Query(query, params.Value, zygosityStr)
+	query, _ := buildGetVariantsQuery(params)
+	rows, err := utilserver.DBConnection.Query(query, params.Annotation, params.Value, zygosityStr, false)
 	if err != nil {
 		logrus.Error("Query execution error " + err.Error())
 		t.Fail()

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -21,17 +21,17 @@ var proteinChangeGetVariantsResult = []string{"-2429151887266669568"}
 var hugoGeneSymbolGetVariantsResult = []string{"-7039476204566471680", "-7039476580443220992", "-7039476780159200256"}
 
 func init() {
-	utilserver.DBMSHost = "localhost"
-	utilserver.DBMSPort = 5432
-	utilserver.DBName = "i2b2medcosrv0"
-	utilserver.DBLoginUser = "i2b2"
-	utilserver.DBLoginPassword = "i2b2"
+	utilserver.DBHost = "localhost"
+	utilserver.DBPort = 5432
+	utilserver.DBName = "gamedcosrv0"
+	utilserver.DBLoginUser = "genomicannotations"
+	utilserver.DBLoginPassword = "genomicannotations"
 	utilserver.SetLogLevel("5")
 }
 
 func TestDBConnection(t *testing.T) {
 	var err error
-	utilserver.DBConnection, err = utilserver.InitializeConnectionToDB(utilserver.DBMSHost, utilserver.DBMSPort, utilserver.DBName, utilserver.DBLoginUser, utilserver.DBLoginPassword)
+	utilserver.DBConnection, err = utilserver.InitializeConnectionToDB(utilserver.DBHost, utilserver.DBPort, utilserver.DBName, utilserver.DBLoginUser, utilserver.DBLoginPassword)
 	if err != nil {
 		t.Fail()
 	}
@@ -82,21 +82,12 @@ func TestGenomicAnnotationsGetVariants(t *testing.T) {
 
 func testGenomicAnnotationsGetValues(query_type string, query_value string, query_result []string, t *testing.T) {
 
+	TestDBConnection(t)
+
 	var annotations []string
 	var annotation string
 	params := genomic_annotations.NewGetValuesParams()
-
 	var err error
-	utilserver.DBConnection, err = utilserver.InitializeConnectionToDB(utilserver.DBMSHost, utilserver.DBMSPort, utilserver.DBName, utilserver.DBLoginUser, utilserver.DBLoginPassword)
-	if err != nil {
-		t.Fail()
-	}
-
-	err = utilserver.DBConnection.Ping()
-	if err != nil {
-		logrus.Error("Impossible to connect to DB " + err.Error())
-		t.Fail()
-	}
 
 	params.Annotation = query_type
 	params.Value = query_value

--- a/util/server/configuration.go
+++ b/util/server/configuration.go
@@ -61,10 +61,10 @@ var OidcJwtUserIDClaim string
 // MedCoObfuscationMin is the minimum variance passed to the random distribution for the obfuscation
 var MedCoObfuscationMin int
 
-// DBHost is the host of the DBMS
+// DBHost is the host of the DB
 var DBHost string
 
-// DBPort is the number of the port used by the DBMS
+// DBPort is the number of the port used by the DB
 var DBPort int
 
 // DBName is the name of the database

--- a/util/server/configuration.go
+++ b/util/server/configuration.go
@@ -61,11 +61,11 @@ var OidcJwtUserIDClaim string
 // MedCoObfuscationMin is the minimum variance passed to the random distribution for the obfuscation
 var MedCoObfuscationMin int
 
-// DBMSHost is the host of the DBMS
-var DBMSHost string
+// DBHost is the host of the DBMS
+var DBHost string
 
-// DBMSPort is the number of the port used by the DBMS
-var DBMSPort int
+// DBPort is the number of the port used by the DBMS
+var DBPort int
 
 // DBName is the name of the database
 var DBName string
@@ -129,19 +129,19 @@ func init() {
 	}
 	MedCoObfuscationMin = int(obf)
 
-	DBMSHost = os.Getenv("PG_DBMS_HOST")
-	DBName = os.Getenv("PG_DB_NAME")
-	DBLoginUser = os.Getenv("PG_DB_USER")
-	DBLoginPassword = os.Getenv("PG_DB_PW")
+	DBHost = os.Getenv("GA_DB_HOST")
+	DBName = os.Getenv("GA_DB_NAME")
+	DBLoginUser = os.Getenv("GA_DB_USER")
+	DBLoginPassword = os.Getenv("GA_DB_PW")
 
-	dbmsPort, err := strconv.ParseInt(os.Getenv("PG_DBMS_PORT"), 10, 64)
-	if err != nil || dbmsPort < 0 || dbmsPort > 65535 {
-		logrus.Warn("invalid DBMS port, defaulted")
-		dbmsPort = 5432
+	dbPort, err := strconv.ParseInt(os.Getenv("GA_DB_PORT"), 10, 64)
+	if err != nil || dbPort < 0 || dbPort > 65535 {
+		logrus.Warn("invalid DB port, defaulted")
+		dbPort = 5432
 	}
-	DBMSPort = int(dbmsPort)
+	DBPort = int(dbPort)
 
-	DBConnection, err = InitializeConnectionToDB(DBMSHost, DBMSPort, DBName, DBLoginUser, DBLoginPassword)
+	DBConnection, err = InitializeConnectionToDB(DBHost, DBPort, DBName, DBLoginUser, DBLoginPassword)
 	if err != nil {
 		logrus.Error("Impossible to initialize connection to DB")
 		return


### PR DESCRIPTION
The main change here is that genomic annotations queries are now performed by using pgsql functions stored in the db. There is also some minor refactoring and renaming.